### PR TITLE
Update guestlist.md

### DIFF
--- a/guestlist.md
+++ b/guestlist.md
@@ -51,3 +51,5 @@
 * Constance Caramanolis  [@ccaramanolis](https://twitter.com/ccaramanolis)
 * Tabitha Sable        [@TabbySable](https://twitter.com/TabbySable)
 * Dave Sudia         [@thedevelopnik](https://twitter.com/thedevelopnik)
+* Jake Madders
+* Jon Lucas


### PR DESCRIPTION
Adding the co-founders of Hyve Managed Hosting - pals from Uni who launched the company from their bedrooms and are now competing against big tech companies like Fastly and Rackspace.